### PR TITLE
Enable / Disable throw button

### DIFF
--- a/src/main/java/com/sw/yutnori/ui/SwingYutControlPanel.java
+++ b/src/main/java/com/sw/yutnori/ui/SwingYutControlPanel.java
@@ -107,29 +107,19 @@ public class SwingYutControlPanel extends JPanel implements GameUI {
     // '지정 윷 던지기' 클릭 시 창 변경
     private void showCustomYutSelectionPanel() {
         removeAll();
+
         Consumer<List<String>> onConfirm = selectedYuts -> {
-            controller.onCustomYutButtonClicked(selectedYuts);
+            controller.onConfirmButtonClicked(selectedYuts);
         };
         Runnable onCancel = this::restoreOriginalPanel;
+
         SwingYutSelectionPanel selectionPanel = new SwingYutSelectionPanel(onConfirm, onCancel);
         add(selectionPanel);
         revalidate();
         repaint();
     }
 
-    private YutResult convertStringToYutResult(String yutType) {
-        return switch (yutType) {
-            case "DO" -> YutResult.DO;
-            case "GAE" -> YutResult.GAE;
-            case "GEOL" -> YutResult.GEOL;
-            case "YUT" -> YutResult.YUT;
-            case "MO" -> YutResult.MO;
-            case "BACK_DO" -> YutResult.BACK_DO;
-            default -> throw new IllegalArgumentException("알 수 없는 윷 타입: " + yutType);
-        };
-    }
-
-    // '지정 윷 던지기'에서 취소/완료 후 원래 패널로 복원
+    // '지정 윷 던지기'에서 취소 후 원래 패널로 복원
     private void restoreOriginalPanel() {
         removeAll();
         layoutComponents();
@@ -238,47 +228,18 @@ public class SwingYutControlPanel extends JPanel implements GameUI {
         return button;
     }
 
-    // !TODO: 게임 턴이 변경될 때 호출 - 아직 미적용
+    // !TODO: 게임 턴이 변경될 때 호출 - 턴 변경 로직 적용 이후 수정 및 확인 필요
     public void startNewTurn() {
         resultDisplay.resetResults();
         currentYutLabel.setText("-");
-        randomYutBtn.setEnabled(true);
-        customYutBtn.setEnabled(true);
-    }
-
-    // 게임 진행 관련
-    private Long getCurrentTurnId() {
-        if (currentTurnId == null) {
-            try {
-                // !TODO: 턴 정보 로직 구현 필요
-                currentTurnId = 1L;
-            } catch (Exception e) {
-                showError("턴 정보를 가져오는데 실패했습니다: " + e.getMessage());
-                currentTurnId = 1L;
-            }
-        }
-        return currentTurnId;
-    }
-
-    public void updateTurnId(Long turnId) {
-        this.currentTurnId = turnId;
-    }
-
-    private Long getSelectedPieceId() {
-        return selectedPieceId;
-    }
-
-    public void resetPieceSelection() {
-        this.selectedPieceId = null;
+        enableRandomButton(true);
+        enableCustomButton(true);
     }
 
     // GameUI 인터페이스 메소드 구현
     @Override
     public void displayYutResult(String result) {
         resultDisplay.displayYutResult(result);
-
-        // 버튼 활성화/비활성화 로직
-        randomYutBtn.setEnabled(resultDisplay.isSpecialResult(result));
     }
 
     @Override
@@ -312,10 +273,6 @@ public class SwingYutControlPanel extends JPanel implements GameUI {
 
     public ResultDisplay getResultDisplay() {
         return resultDisplay;
-    }
-
-    public void setRandomYutButtonEnabled(boolean enabled) {
-        randomYutBtn.setEnabled(enabled);
     }
 
     public void showWinnerDialog(String winnerName) {
@@ -357,9 +314,14 @@ public class SwingYutControlPanel extends JPanel implements GameUI {
         updateYutSticks(result);
     }
 
-    // 랜덤 윷 버튼 활성화
+    // 랜덤 윷 버튼 활성화 및 비활성화
     public void enableRandomButton(boolean enabled) {
         randomYutBtn.setEnabled(enabled);
+    }
+
+    // 지정 윷 버튼 활성화 및 비활성화
+    public void enableCustomButton(boolean enabled) {
+        customYutBtn.setEnabled(enabled);
     }
 
     // 오류 메시지 표시 및 원래 패널로 복원

--- a/src/main/java/com/sw/yutnori/ui/display/SelectionDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/display/SelectionDisplay.java
@@ -10,6 +10,8 @@ public interface SelectionDisplay {
 
     void updateSelectedYutsPanel();
 
+    boolean isSpecialResult(String result);
+
     void setOnConfirmCallback(Consumer<List<String>> callback);
     void setOnCancelCallback(Runnable callback);
 

--- a/src/main/java/com/sw/yutnori/ui/display/SwingResultDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/display/SwingResultDisplay.java
@@ -1,6 +1,5 @@
 package com.sw.yutnori.ui.display;
 
-import com.sw.yutnori.common.enums.YutResult;
 import javax.swing.*;
 
 public class SwingResultDisplay implements ResultDisplay {
@@ -16,7 +15,7 @@ public class SwingResultDisplay implements ResultDisplay {
     @Override
     public void displayYutResult(String result) {
         // 윷이나 모인 경우 특별 처리
-        if (result.equals("윷") || result.equals("모")) {
+        if (isSpecialResult(result)) {
             handleSpecialResult(result);
         } else {
             handleNormalResult(result);
@@ -26,6 +25,7 @@ public class SwingResultDisplay implements ResultDisplay {
         updateCurrentYut(convertYutTypeToEnglish(result));
     }
 
+    // 윷 혹은 모가 나온 경우 결과 처리
     private void handleSpecialResult(String result) {
         String currentText = resultLabels[currentResultIndex].getText();
 
@@ -43,6 +43,7 @@ public class SwingResultDisplay implements ResultDisplay {
         resultLabels[currentResultIndex].setText(result);
     }
 
+    // 윷 혹은 모 이외의 결과 처리
     private void handleNormalResult(String result) {
         if (resultLabels[currentResultIndex].getText().equals("-")) {
             resultLabels[currentResultIndex].setText(result);
@@ -77,6 +78,7 @@ public class SwingResultDisplay implements ResultDisplay {
         return result.equals("윷") || result.equals("모");
     }
 
+    // 윷이나 모가 나올 경우 나온 횟수를 HTML 태그 활용해 윗첨자로 표시
     private String formatYutResultWithSuperscript(String result, String currentText) {
         // HTML 태그가 있는지 확인
         if (currentText.startsWith("<html>")) {

--- a/src/main/java/com/sw/yutnori/ui/display/SwingSelectionDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/display/SwingSelectionDisplay.java
@@ -184,7 +184,7 @@ public class SwingSelectionDisplay implements SelectionDisplay {
 
         // 결과 분류
         for (String yut : selectedYuts) {
-            if (yut.equals("윷") || yut.equals("모")) {
+            if (isSpecialResult(yut)) {
                 yutMoCount.put(yut, yutMoCount.getOrDefault(yut, 0) + 1);
             } else {
                 if (!otherResults.contains(yut)) {
@@ -228,6 +228,11 @@ public class SwingSelectionDisplay implements SelectionDisplay {
     @Override
     public List<String> getSelectedYuts() {
         return new ArrayList<>(selectedYuts);
+    }
+
+    @Override
+    public boolean isSpecialResult(String result) {
+        return result.equals("윷") || result.equals("모");
     }
 
     @Override

--- a/src/main/java/com/sw/yutnori/ui/display/SwingYutDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/display/SwingYutDisplay.java
@@ -42,7 +42,7 @@ public class SwingYutDisplay implements YutDisplay {
             case "MO": // 모 (4개 모두 앞면)
                 // 초기화된 상태와 동일
                 break;
-            case "BACK_DO": // 빽도 (1개 뒤집힘, 특별 처리 필요시)
+            case "BACK_DO": // 빽도 (별도 관리)
                 displayBackDo(random);
                 break;
         }
@@ -55,6 +55,7 @@ public class SwingYutDisplay implements YutDisplay {
         }
     }
 
+    // 랜덤 적용해 윷이 매번 다르게 뒤집히도록 함
     private void flipRandomSticks(int count, Random random) {
         boolean[] flipped = new boolean[4];
         int flippedCount = 0;


### PR DESCRIPTION
- `InGameController`: 윷 지정 후 '완료' 버튼 클릭 시 이전 패널로 돌아가는 `restorePanel()` 실행 이후 '랜덤 윷 던지기' 및 '지정 윷 던지기' 버튼 모두 비활성화되도록 수정 (윷 지정 이후에는 말을 선택하는 단계이므로 윷을 제어할 필요가 없음)
- `SelectionDisplay`: `ResultDisplay`의 `isSpecialResult()`를 동일하게 적용
- `SwingYutControlPanel`: view와 controller 분리 시 view에 남아 있던 중복된 메소드 제거 및 `enableCustomButton()` 추가
- 기타 주석 보완