### PR TITLE
fix piece gui issue

### DIFF
--- a/src/main/java/com/sw/yutnori/controller/InGameController.java
+++ b/src/main/java/com/sw/yutnori/controller/InGameController.java
@@ -151,21 +151,32 @@ public class InGameController {
             return;
         }
 
+        // index+1로 표시(말 번호는 양측 모두 1부터 n(2<=n<=5) 순서대로 표시), PieceId로 매핑
+        String[] displayOptions = new String[pieces.size()];
+        Long[] pieceIds = new Long[pieces.size()];
+        for (int i = 0; i < pieces.size(); i++) {
+            displayOptions[i] = (i + 1) + "번";
+            pieceIds[i] = pieces.get(i).getPieceId();
+        }
+
         Object selected = JOptionPane.showInputDialog(
                 null,
                 "사용할 말을 선택하세요",
                 "말 선택",
                 JOptionPane.PLAIN_MESSAGE,
                 null,
-                pieces.stream().map(Piece::getPieceId).toArray(),
-                pieces.get(0).getPieceId()
+                displayOptions,
+                displayOptions[0]
         );
 
         if (selected != null) {
-            selectedPieceId = (Long) selected;
-            if (pendingRandomYutResult != null) {
-                onConfirmButtonClicked(List.of(pendingRandomYutResult.name()));
-                pendingRandomYutResult = null;
+            int selectedIdx = java.util.Arrays.asList(displayOptions).indexOf(selected.toString());
+            if (selectedIdx >= 0) {
+                selectedPieceId = pieceIds[selectedIdx];
+                if (pendingRandomYutResult != null) {
+                    onConfirmButtonClicked(List.of(pendingRandomYutResult.name()));
+                    pendingRandomYutResult = null;
+                }
             }
         }
     }

--- a/src/main/java/com/sw/yutnori/ui/SwingYutBoardPanel.java
+++ b/src/main/java/com/sw/yutnori/ui/SwingYutBoardPanel.java
@@ -233,7 +233,9 @@ public class SwingYutBoardPanel extends JPanel {
                     // 노드 중심과 버튼 중앙이 일치하도록 배치
                     int x = (int) node.getX() + offsetX - (pieceSize / 2);
                     int y = (int) node.getY() + offsetY - (pieceSize / 2);
-                    JButton btn = new JButton(String.valueOf(piece.getPieceId()));
+                    // 말 번호는 양측 모두 1부터 n(2<=n<=5) 순서대로 표시
+                    int displayNum = player.getPieces().indexOf(piece) + 1;
+                    JButton btn = new JButton(String.valueOf(displayNum));
                     btn.setBounds(x, y, pieceSize, pieceSize);
                     btn.setBackground(color);
                     btn.setOpaque(true);

--- a/src/main/java/com/sw/yutnori/ui/SwingYutBoardPanel.java
+++ b/src/main/java/com/sw/yutnori/ui/SwingYutBoardPanel.java
@@ -238,6 +238,7 @@ public class SwingYutBoardPanel extends JPanel {
                     btn.setBackground(color);
                     btn.setOpaque(true);
                     btn.setBorderPainted(false);
+                    btn.setMargin(new Insets(0, 0, 0, 0));
                     pieceButtons.put(piece.getPieceId(), btn);
                     add(btn);
                 }


### PR DESCRIPTION
구현 사항
- 마진 조정을 통해 문자 제대로 표시되게 수정함
- 말 번호는 양측 모두 1부터 n(2<=n<=5) 순서대로 표시

before:
![image](https://github.com/user-attachments/assets/ab7380f8-4237-4208-9bda-51a925c78b6e)

after:
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/27900ac5-ae58-4995-8777-13b1c0baf6c5" />
