### PR TITLE
[fix] #69 - Yut Control

### DIFF
--- a/src/main/java/com/sw/yutnori/logic/GameManager.java
+++ b/src/main/java/com/sw/yutnori/logic/GameManager.java
@@ -12,6 +12,8 @@ public class GameManager {
     private final Map<Long, Player> playerMap = new HashMap<>();
     private final Map<Long, Piece> pieceMap = new HashMap<>();
 
+    private final List<YutResult> yutResults = new ArrayList<>();
+
     private long pieceIdCounter = 1;
 
     private long generatePieceId() {
@@ -102,6 +104,22 @@ public class GameManager {
         else if (r < 0.8) return YutResult.GEOL;
         else if (r < 0.95) return YutResult.YUT;
         else return YutResult.MO;
+    }
+
+    public void addYutResult(YutResult result) {
+        yutResults.add(result);
+    }
+
+    public List<YutResult> getYutResults() {
+        return yutResults;
+    }
+
+    public void deleteYutResult(YutResult result) {
+        yutResults.remove(result);
+    }
+
+    public void clearYutResults() {
+        yutResults.clear();
     }
 
     public MovePieceResult movePiece(Long pieceId, YutResult result) {
@@ -202,6 +220,7 @@ public class GameManager {
         }
         int nextIndex = (index + 1) % players.size();
         currentGame.setCurrentTurnPlayer(players.get(nextIndex)); // 이 줄 꼭 필요
+        clearYutResults();
     }
 
 

--- a/src/main/java/com/sw/yutnori/ui/display/ResultDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/display/ResultDisplay.java
@@ -1,8 +1,14 @@
 package com.sw.yutnori.ui.display;
 
+import com.sw.yutnori.model.enums.YutResult;
+
+import java.util.List;
+
 public interface ResultDisplay {
 
     void displayYutResult(String result);
+
+    void syncWithYutResults(List<YutResult> yutResults);
 
     void updateCurrentYut(String yutType);
 

--- a/src/main/java/com/sw/yutnori/ui/display/YutDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/display/YutDisplay.java
@@ -2,7 +2,7 @@ package com.sw.yutnori.ui.display;
 
 public interface YutDisplay {
 
-    void displayYutResult(String yutType);
+    void displayYutSticks(String yutType);
 
     void reset();
 }

--- a/src/main/java/com/sw/yutnori/ui/swing/display/SwingYutDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/display/SwingYutDisplay.java
@@ -23,7 +23,7 @@ public class SwingYutDisplay implements YutDisplay {
     }
 
     @Override
-    public void displayYutResult(String yutType) {
+    public void displayYutSticks(String yutType) {
         reset();
 
         Random random = new Random();

--- a/src/main/java/com/sw/yutnori/ui/swing/panel/SwingYutControlPanel.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/panel/SwingYutControlPanel.java
@@ -21,12 +21,10 @@ import java.util.List;
 public class SwingYutControlPanel extends JPanel {
 
     private final ControlDisplay controlDisplay;
-
-    private Long playerId;
-
-    private final InGameController controller;
     private final YutDisplay yutDisplay;
     private final ResultDisplay resultDisplay;
+
+    private final InGameController controller;
 
     public SwingYutControlPanel(InGameController controller) {
         setLayout(new BorderLayout());
@@ -43,11 +41,6 @@ public class SwingYutControlPanel extends JPanel {
         controlDisplay.setOnCustomYutCallback(this::showCustomYutSelectionPanel);
     }
 
-    // 플레이어 ID 설정
-    public void setGameContext(Long playerId) {
-        this.playerId = playerId;
-    }
-
     // 선택 UI 또는 패널 활성화 로직
     public void enableYutSelection() {
         System.out.println("윷 선택 UI를 활성화합니다.");
@@ -57,11 +50,7 @@ public class SwingYutControlPanel extends JPanel {
     private void showCustomYutSelectionPanel() {
         removeAll();
 
-        Consumer<List<String>> onConfirm = selectedYuts -> {
-            controller.promptPieceSelection(playerId); // 말 선택 창 띄움
-            controller.onConfirmButtonClicked(selectedYuts); // '완료' 버튼 클릭 시 발생하는 이벤트
-
-        };
+        Consumer<List<String>> onConfirm = controller::onConfirmButtonClicked;
         Runnable onCancel = this::restorePanel;
 
         SwingYutSelectionPanel selectionPanel = new SwingYutSelectionPanel(onConfirm, onCancel);
@@ -122,26 +111,11 @@ public class SwingYutControlPanel extends JPanel {
         });
     }
 
-    // 윷 결과 업데이트
-    public void updateYutResult(String koreanResult, String result) {
-        displayYutResult(koreanResult);
-        updateCurrentYut(result);
-        updateYutSticks(result);
+    // 윷 및 결과창 업데이트
+    public void updateDisplay(String result) {
+        yutDisplay.displayYutSticks(result);
+        resultDisplay.updateCurrentYut(result);
     }
-
-    public void displayYutResult(String result) {
-        resultDisplay.displayYutResult(result);
-    }
-
-    public void updateCurrentYut(String yutType) {
-        resultDisplay.updateCurrentYut(yutType);
-        yutDisplay.displayYutResult(yutType);
-    }
-
-    public void updateYutSticks(String yutType) {
-        yutDisplay.displayYutResult(yutType);
-    }
-
 
     // 랜덤 윷 버튼 활성화 및 비활성화
     public void enableRandomButton(boolean enabled) {


### PR DESCRIPTION
# PR 타입
- ✅ 기능 추가
- ⚠️ 버그 수정
- 🛠️ 리팩토링

# 반영 브랜치
- #12 ← #69

# 주요 내용
- #51 및 #52 수정
- '지정 윷 던지기' 패널의 완료 버튼 이벤트 리팩토링 
- 실제 윷놀이 게임 흐름에 맞게 다음과 같이 로직 수정

**[랜덤 윷 던지기]**
1. 버튼 클릭해 윷을 던짐. 만약 윷이나 모가 나올 경우 그 이외의 값이 나올 때 까지 계속 버튼 클릭해 윷을 던져야 함
2. 윷, 모 이외의 값이 나오면 윷 던지기 종료 후 이동을 원하는 말을 선택
3. 해당 말에 적용할 윷 값 선택 후 이동. 만약 말을 잡았을 경우 윷을 한번 더 던짐
4. 더 이상 이동할 말이 없으면 다음 플레이어로 턴 변경

**[지정 윷 던지기]**
1. 버튼 클릭해 원하는 윷을 모두 선택. 이때 윷놀이 규칙에 어긋나는 윷 선택은 불가
2. 선택 종료 후 '완료' 버튼 클릭하면 [랜덤 윷 던지기]와 동일한 말 선택 및 윷 선택 로직 적용됨. 윷을 미리 지정하기 때문에 말을 잡아도 별도로 윷을 한번 더 던지거나 추가하는 로직은 없음
3. 지정한 모든 윷 값을 사용하면 다음 플레이어로 턴 변경

# 변경 사항
### `GameManager`
- '랜덤 윷 던지기' 버튼을 눌러 나온 윷 결과값과 '지정 윷 던지기' 패널에서 선택한 윷 결과값을 저장하는 `yutResults` 리스트 및 관련 메소드 추가
### `InGameController`
- `onConfirmButtonClicked()`는 '지정 윷 던지기' 패널에서 사용자가 선택을 끝내고 '완료' 버튼을 클릭했을 때 발생하는 이벤트를 처리하는 메소드이지만 **말 이동 및 턴 처리 로직까지 담당하고 있었음**. 이를 `processTurn()`으로 리팩토링해 이벤트만 처리하도록 변경
- `promptPieceSelection()`에서 말 선택 후 해당 말에 적용될 윷 값을 선택할 수 있도록 `promptYutSelection()`을 추가
- `onRandomYutButtonClicked()`와 `onConfirmYutButtonClicked()` 로직을 실제 윷놀이 게임과 동일하게 변경
### `ResultDisplay`
- 윷이나 모가 연속으로 나왔을 때 윗첨자로 추가되지 않고 옆으로 계속 이어져서 추가되는 문제 및 영문 표기 문제 수정
- 윗첨자 추가 로직 보완
- `GameManager`의 `yutResults` 리스트와 화면에 표시되는 라벨이 연동되도록 `syncWithYutResults()` 추가
### `SwingYutControlPanel`
- 윷 결과를 업데이트하는 `updateYutResult`에서 `ResultDisplay`의 업데이트를 `syncWithYutResults()`로 분리 후 목적에 맞게 메소드명을 `updateDisplay`로 변경
- 이제 GameContext와 관련된 내용은 모두 `InGameController`에서 담당하고 있으므로 `playerId` 필드와 `setGameContext()` 삭제
- '완료' 버튼 콜백 수정

# 테스트 결과 및 차후 과제
- 윷을 던지고 이에 맞게 말을 움직이는데는 아직 문제가 없지만 분기점에서 말이 사라지거나 말이 제대로 업히지 않는 문제가 있어 수정 필요
- 아직 게임 시작 후 종료까지 이어지지 못하므로 지속적인 오류 수정 및 보완 필요