### PR TITLE
Carry

### DIFF
--- a/src/main/java/com/sw/yutnori/controller/InGameController.java
+++ b/src/main/java/com/sw/yutnori/controller/InGameController.java
@@ -17,9 +17,13 @@ import com.sw.yutnori.ui.display.GameSetupDisplay;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class InGameController {
     private final Board boardModel;
@@ -204,6 +208,12 @@ public class InGameController {
             }
             if (moveResult.groupingOccurred()) {
                 List<Long> groupedIds = moveResult.groupedAllyPieceIds();
+                if (!groupedIds.isEmpty()) {
+                    // 그룹 대표 pieceId로 그룹 객체 찾기
+                    List<Piece> group = groupedIds.stream().map(gameManager::getPiece).toList();
+                    String groupedStr = gameManager.getGroupDisplayString(group);
+                    System.out.println("[디버깅] 업힌 그룹: " + groupedStr);
+                }
                 String grouped = groupedIds.stream()
                         .map(id -> {
                             Player p = gameManager.getPiece(id).getPlayer();
@@ -258,40 +268,50 @@ public class InGameController {
             yutControlPanel.showError("플레이어 정보를 찾을 수 없습니다.");
             return;
         }
-        // READY 또는 ON_BOARD && !FINISHED인 말만 선택 옵션으로 제시
-        List<Piece> pieces = player.getPieces().stream()
+        // 그룹핑된 말 그룹 추출
+        List<List<Piece>> grouped = gameManager.getGroupedPieceLists(player);
+        Set<Long> groupedIds = new HashSet<>();
+        for (List<Piece> group : grouped) {
+            for (Piece p : group) groupedIds.add(p.getPieceId());
+        }
+        // 그룹이 아닌 개별 말(READY/ON_BOARD, isGrouped==false, !FINISHED)
+        List<Piece> singles = player.getPieces().stream()
                 .filter(p -> (p.getState() == com.sw.yutnori.model.enums.PieceState.READY ||
                               p.getState() == com.sw.yutnori.model.enums.PieceState.ON_BOARD)
-                             && !p.isFinished())
+                             && !p.isFinished() && !groupedIds.contains(p.getPieceId()))
                 .toList();
-        if (pieces.isEmpty()) {
+        // 옵션 구성: 그룹 + 개별
+        List<String> displayList = new ArrayList<>();
+        List<Long> pieceIdList = new ArrayList<>();
+        for (List<Piece> group : grouped) {
+            displayList.add(gameManager.getGroupDisplayString(group));
+            // 대표 pieceId(가장 작은 값)
+            pieceIdList.add(group.stream().min(Comparator.comparing(Piece::getPieceId)).get().getPieceId());
+        }
+        for (Piece p : singles) {
+            int idx = player.getPieces().indexOf(p) + 1;
+            displayList.add(String.valueOf(idx));
+            pieceIdList.add(p.getPieceId());
+        }
+        if (displayList.isEmpty()) {
             yutControlPanel.showError("선택 가능한 말이 없습니다.");
             return;
         }
-
-        // index+1로 표시(말 번호는 양측 모두 1부터 n(2<=n<=5) 순서대로 표시), PieceId로 매핑
-        String[] displayOptions = new String[pieces.size()];
-        Long[] pieceIds = new Long[pieces.size()];
-        for (int i = 0; i < pieces.size(); i++) {
-            displayOptions[i] = (i + 1) + "번";
-            pieceIds[i] = pieces.get(i).getPieceId();
-        }
-
+        String[] displayOptions = displayList.toArray(new String[0]);
+        Long[] pieceIds = pieceIdList.toArray(new Long[0]);
         Object selected = JOptionPane.showInputDialog(
                 null,
-                "[" + player.getName() + "] 사용할 말을 선택하세요",  // 🔹 수정된 부분
+                "[" + player.getName() + "] 사용할 말을 선택하세요",
                 "말 선택",
                 JOptionPane.PLAIN_MESSAGE,
                 null,
                 displayOptions,
                 displayOptions[0]
         );
-
         if (selected != null) {
             int selectedIdx = java.util.Arrays.asList(displayOptions).indexOf(selected.toString());
             if (selectedIdx >= 0) {
                 selectedPieceId = pieceIds[selectedIdx];
-                    // yutBoardPanel.highlightSelectedPiece(selectedPieceId);
             }
         }
     }

--- a/src/main/java/com/sw/yutnori/controller/InGameController.java
+++ b/src/main/java/com/sw/yutnori/controller/InGameController.java
@@ -95,7 +95,29 @@ public class InGameController {
         }
     }
 
-    // onConfirmButtonClicked()에서 말 이동 및 턴 처리 로직 분리
+    // 턴 처리 로직 분리
+    public void handleTurnChange(boolean requiresAnotherMove) {
+        if (!requiresAnotherMove) {
+            gameManager.nextTurn(playerId);
+            Long nextPlayerId = gameManager.getCurrentGame().getCurrentTurnPlayer().getId();
+            setGameContext(nextPlayerId);
+            yutControlPanel.startNewTurn();
+        } else {
+            // 오직 랜덤 윷 버튼으로 추가된 턴에만 자동 실행
+            if (yutControlPanel.wasRandomYutButtonUsed()) {
+                SwingUtilities.invokeLater(() -> onRandomYutButtonClicked());
+            } else {
+                JOptionPane.showMessageDialog(null, "한 번 더 이동할 수 있습니다. 윷을 던지세요.", "추가 턴", JOptionPane.INFORMATION_MESSAGE);
+                yutControlPanel.enableRandomButton(true);
+                yutControlPanel.enableCustomButton(true);
+            }
+        }
+
+        // 모든 플레이어의 상태 패널 갱신
+        for (Player player : gameManager.getCurrentGame().getPlayers()) {
+            statusPanel.updatePlayerStatus(player);
+        }
+    }
 
     // onConfirmButtonClicked()에서 말 이동 및 턴 처리 로직 분리
     private void processTurn() {
@@ -207,37 +229,14 @@ public class InGameController {
             yutBoardPanel.refreshAllPieceMarkers(gameManager.getCurrentGame().getPlayers());
             yutControlPanel.getResultDisplay().syncWithYutResults(gameManager.getYutResults());
 
-            handleTurnChange(moveResult.requiresAnotherMove());
+            boolean anotherMove = (selectedYutResult == YutResult.YUT 
+            || selectedYutResult == YutResult.MO || moveResult.captureOccurred());
+            handleTurnChange(anotherMove);
 
         } catch (Exception ex) {
             handleError(ex);
         } finally {
             yutControlPanel.restorePanel();
-        }
-    }
-
-
-    // 턴 처리 로직 분리
-    public void handleTurnChange(boolean requiresAnotherMove) {
-        if (!requiresAnotherMove) {
-            gameManager.nextTurn(playerId);
-            Long nextPlayerId = gameManager.getCurrentGame().getCurrentTurnPlayer().getId();
-            setGameContext(nextPlayerId);
-            yutControlPanel.startNewTurn();
-        } else {
-            // 오직 랜덤 윷 버튼으로 추가된 턴에만 자동 실행
-            if (yutControlPanel.wasRandomYutButtonUsed()) {
-                SwingUtilities.invokeLater(() -> onRandomYutButtonClicked());
-            } else {
-                JOptionPane.showMessageDialog(null, "한 번 더 이동할 수 있습니다. 윷을 던지세요.", "추가 턴", JOptionPane.INFORMATION_MESSAGE);
-                yutControlPanel.enableRandomButton(true);
-                yutControlPanel.enableCustomButton(true);
-            }
-        }
-
-        // 모든 플레이어의 상태 패널 갱신
-        for (Player player : gameManager.getCurrentGame().getPlayers()) {
-            statusPanel.updatePlayerStatus(player);
         }
     }
 

--- a/src/main/java/com/sw/yutnori/logic/GameManager.java
+++ b/src/main/java/com/sw/yutnori/logic/GameManager.java
@@ -301,4 +301,41 @@ public class GameManager {
         return !hasOnBoardPiece(player);
     }
 
+    // 플레이어의 그룹핑된 말(같은 위치, isGrouped==true)을 그룹별로 반환
+    public List<List<Piece>> getGroupedPieceLists(Player player) {
+        List<Piece> onBoard = getOnBoardPieces(player);
+        List<List<Piece>> groups = new ArrayList<>();
+        Set<Long> visited = new HashSet<>();
+        for (Piece p : onBoard) {
+            if (visited.contains(p.getPieceId())) continue;
+            if (p.isGrouped()) {
+                // 같은 위치, 같은 player, isGrouped==true
+                List<Piece> group = new ArrayList<>();
+                for (Piece other : onBoard) {
+                    if (other.getA() == p.getA() && other.getB() == p.getB() && other.isGrouped()) {
+                        group.add(other);
+                        visited.add(other.getPieceId());
+                    }
+                }
+                // 대표 pieceId가 가장 작은 말이 그룹 대표
+                group.sort(Comparator.comparing(Piece::getPieceId));
+                groups.add(group);
+            }
+        }
+        return groups;
+    }
+
+    // 그룹(말 리스트)을 "1,2,3" 식으로 표시하는 문자열 반환
+    public String getGroupDisplayString(List<Piece> group) {
+        if (group == null || group.isEmpty()) return "";
+        Player player = group.get(0).getPlayer();
+        List<Piece> all = player.getPieces();
+        List<Integer> nums = new ArrayList<>();
+        for (Piece p : group) {
+            int idx = all.indexOf(p);
+            if (idx >= 0) nums.add(idx + 1);
+        }
+        nums.sort(Integer::compareTo);
+        return nums.stream().map(String::valueOf).reduce((a,b)->a+","+b).orElse("") ;
+    }
 }

--- a/src/main/java/com/sw/yutnori/ui/swing/display/SwingControlDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/display/SwingControlDisplay.java
@@ -104,7 +104,6 @@ public class SwingControlDisplay implements ControlDisplay {
             resultLabels[i] = new JLabel("-");
             resultLabels[i].setHorizontalAlignment(SwingConstants.CENTER);
             resultLabels[i].setName("resultLabel" + i);
-            resultLabels[i].setFont(new Font("맑은 고딕", Font.BOLD, 32));
             panel.add(resultLabels[i]);
         }
 
@@ -120,7 +119,6 @@ public class SwingControlDisplay implements ControlDisplay {
 
         currentYutLabel = new JLabel("-");
         currentYutLabel.setName("currentYutLabel");
-        currentYutLabel.setFont(new Font("맑은 고딕", Font.BOLD, 32));
         panel.add(currentYutLabel);
 
         return panel;

--- a/src/main/java/com/sw/yutnori/ui/swing/display/SwingSelectionDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/display/SwingSelectionDisplay.java
@@ -172,7 +172,6 @@ public class SwingSelectionDisplay implements SelectionDisplay {
     private JButton createYutButton(String text) {
         JButton button = new JButton(text);
         button.setPreferredSize(new Dimension(60, 60));
-        button.setFont(new Font("맑은 고딕", Font.BOLD, 16));
         return button;
     }
 

--- a/src/main/java/com/sw/yutnori/ui/swing/display/SwingSelectionDisplay.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/display/SwingSelectionDisplay.java
@@ -63,7 +63,6 @@ public class SwingSelectionDisplay implements SelectionDisplay {
         for (int i = 0; i < 3; i++) {
             JLabel label = new JLabel("-");
             label.setHorizontalAlignment(SwingConstants.CENTER);
-            label.setFont(new Font("맑은 고딕", Font.BOLD, 32));
             selectedYutsPanel.add(label);
         }
 

--- a/src/main/java/com/sw/yutnori/ui/swing/panel/SwingYutBoardPanel.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/panel/SwingYutBoardPanel.java
@@ -269,7 +269,6 @@ public class SwingYutBoardPanel extends JPanel {
                     pieceLabel.setOpaque(true);
                     pieceLabel.setBackground(color);
                     pieceLabel.setForeground(Color.BLACK);
-                    pieceLabel.setFont(new Font("맑은 고딕", Font.PLAIN, 16));
                     pieceButtons.put(piece.getPieceId(), pieceLabel);
                     add(pieceLabel);
                 }

--- a/src/main/java/com/sw/yutnori/ui/swing/panel/SwingYutBoardPanel.java
+++ b/src/main/java/com/sw/yutnori/ui/swing/panel/SwingYutBoardPanel.java
@@ -10,6 +10,8 @@ package com.sw.yutnori.ui.swing.panel;
 import javax.swing.*;
 import java.awt.*;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 import java.awt.event.MouseEvent;
 import java.util.HashMap;
@@ -233,8 +235,29 @@ public class SwingYutBoardPanel extends JPanel {
 
         for (Player player : players) {
             Color color = ColorUtils.parseColor(player.getColor());
+            // 그룹핑된 말 그룹 표시
+            List<List<Piece>> grouped = gameManager.getGroupedPieceLists(player);
+            Set<Long> groupedIds = new HashSet<>();
+            for (List<Piece> group : grouped) {
+                if (group.isEmpty()) continue;
+                Piece rep = group.get(0); // 대표
+                Node node = board.findNode(rep.getA(), rep.getB());
+                if (node == null) continue;
+                int x = (int) node.getX() + offsetX - (pieceSize / 2);
+                int y = (int) node.getY() + offsetY - (pieceSize / 2);
+                String labelText = gameManager.getGroupDisplayString(group);
+                JLabel pieceLabel = new JLabel(labelText, SwingConstants.CENTER);
+                pieceLabel.setToolTipText(labelText);
+                pieceLabel.setBounds(x, y, pieceSize, pieceSize);
+                pieceLabel.setOpaque(true);
+                pieceLabel.setBackground(color);
+                pieceButtons.put(rep.getPieceId(), pieceLabel);
+                add(pieceLabel);
+                for (Piece p : group) groupedIds.add(p.getPieceId());
+            }
+            // 그룹이 아닌 개별 말 표시
             for (Piece piece : player.getPieces()) {
-                if (piece.getState() == PieceState.ON_BOARD && !piece.isFinished()) {
+                if ((piece.getState() == PieceState.ON_BOARD && !piece.isFinished()) && !groupedIds.contains(piece.getPieceId())) {
                     Node node = board.findNode(piece.getA(), piece.getB());
                     if (node == null) continue;
                     int x = (int) node.getX() + offsetX - (pieceSize / 2);


### PR DESCRIPTION
- fixed small issue
- https://github.com/sw-team-16/sw_16/issues/74
  - 이동할 말 선택 `,`로 그룹화
  - Board ui에서 말 `,`로 그룹화
    - 말이 4개 이상일 경우 (4..5) `...`으로 표시됨 (크기제한이슈) 
  - UI에서 그룹을 하나의 버튼/라벨로 표시할 때 내부적으로 클릭/선택 이벤트를 처리하려면 해당 그룹을 대표하는 하나의 pieceId가 필요해 가장 작은 pieceId(혹은 그룹의 첫 번째 말 등)를 임시로 대표로 씀 (e.g. `1,2,3` -> 대표 = 1)
- unify font to default